### PR TITLE
Add more stats components to admin page

### DIFF
--- a/src/components/RecentOrders.tsx
+++ b/src/components/RecentOrders.tsx
@@ -1,0 +1,83 @@
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+
+export const RecentOrders = () => {
+  const { data: recentOrders } = useQuery({
+    queryKey: ['recent-orders'],
+    queryFn: async () => {
+      const { data } = await supabase
+        .from('Orders')
+        .select(`
+          order_id,
+          total_amount,
+          status,
+          order_date,
+          product_name,
+          color,
+          Users!Orders_user_id_fkey(Name)
+        `)
+        .order('order_date', { ascending: false })
+        .limit(4);
+
+      return data || [];
+    }
+  });
+
+  const getStatusBadge = (status: string) => {
+    const styles = {
+      pending: "bg-yellow-100 text-yellow-800",
+      processing: "bg-blue-100 text-blue-800", 
+      delivered: "bg-green-100 text-green-800",
+      cancelled: "bg-red-100 text-red-800"
+    };
+
+    const labels = {
+      pending: "Pending",
+      processing: "Processing",
+      delivered: "Delivered",
+      cancelled: "Cancelled"
+    };
+
+    return (
+      <span className={`px-2 py-1 rounded-full text-xs font-medium ${styles[status as keyof typeof styles] || styles.pending}`}>
+        {labels[status as keyof typeof labels] || status}
+      </span>
+    );
+  };
+
+  return (
+    <div className="bg-card p-6 rounded-xl shadow-sm border border-border">
+      <div className="mb-6">
+        <h3 className="text-lg font-semibold text-foreground mb-2">Recent Orders</h3>
+        <p className="text-sm text-muted-foreground">Latest orders from customers</p>
+      </div>
+
+      <div className="space-y-4">
+        {recentOrders?.map((order) => (
+          <div key={order.order_id} className="flex items-center justify-between p-4 bg-muted/20 rounded-lg">
+            <div className="flex-1">
+              <div className="flex items-center justify-between mb-2">
+                <span className="font-medium text-foreground">{order.order_id}</span>
+                {getStatusBadge(order.status || 'pending')}
+              </div>
+              <p className="text-sm text-muted-foreground mb-1">{order.Users?.Name || 'Unknown Customer'}</p>
+              <p className="text-sm text-muted-foreground">{order.product_name || 'Product'}</p>
+            </div>
+            <div className="text-right">
+              <p className="font-semibold text-foreground">${order.total_amount || 0}</p>
+              <p className="text-sm text-muted-foreground">
+                {order.order_date ? new Date(order.order_date).toLocaleDateString() : 'N/A'}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-6 text-center">
+        <button className="text-primary hover:text-primary/80 font-medium text-sm">
+          View all orders →
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/SalesChart.tsx
+++ b/src/components/SalesChart.tsx
@@ -1,0 +1,82 @@
+import { useQuery } from "@tanstack/react-query";
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import { supabase } from "@/integrations/supabase/client";
+
+export const SalesChart = () => {
+  const { data: salesData } = useQuery({
+    queryKey: ['sales-chart'],
+    queryFn: async () => {
+      const { data } = await supabase
+        .from('Orders')
+        .select('order_date, total_amount')
+        .order('order_date', { ascending: true });
+
+      // Group by month and sum total amounts
+      const monthlyData = data?.reduce((acc: any, order) => {
+        if (!order.order_date || !order.total_amount) return acc;
+        
+        const date = new Date(order.order_date);
+        const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+        
+        if (!acc[monthKey]) {
+          acc[monthKey] = {
+            name: date.toLocaleDateString('en-US', { month: 'short' }),
+            value: 0
+          };
+        }
+        acc[monthKey].value += order.total_amount;
+        return acc;
+      }, {});
+
+      return Object.values(monthlyData || {}).slice(-12);
+    }
+  });
+
+  const formatCurrency = (value: number) => {
+    return `$${(value / 1000).toFixed(1)}K`;
+  };
+
+  return (
+    <div className="bg-card p-6 rounded-xl shadow-sm border border-border">
+      <div className="mb-6">
+        <h3 className="text-lg font-semibold text-foreground mb-2">Monthly Revenue</h3>
+        <p className="text-sm text-muted-foreground">Revenue statistics for the last 12 months</p>
+      </div>
+      
+      <div className="h-80">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={salesData || []}>
+            <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+            <XAxis 
+              dataKey="name" 
+              stroke="hsl(var(--muted-foreground))"
+              fontSize={12}
+            />
+            <YAxis 
+              stroke="hsl(var(--muted-foreground))"
+              fontSize={12}
+              tickFormatter={formatCurrency}
+            />
+            <Tooltip 
+              formatter={(value: number) => [formatCurrency(value), 'Revenue']}
+              labelStyle={{ color: 'hsl(var(--foreground))' }}
+              contentStyle={{ 
+                backgroundColor: 'hsl(var(--card))', 
+                border: '1px solid hsl(var(--border))',
+                borderRadius: '8px'
+              }}
+            />
+            <Line 
+              type="monotone" 
+              dataKey="value" 
+              stroke="hsl(var(--primary))" 
+              strokeWidth={3}
+              dot={{ fill: 'hsl(var(--primary))', strokeWidth: 2, r: 4 }}
+              activeDot={{ r: 6, stroke: 'hsl(var(--primary))', strokeWidth: 2 }}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+};

--- a/src/components/UserTable.tsx
+++ b/src/components/UserTable.tsx
@@ -1,0 +1,110 @@
+import { Edit, Trash2 } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+
+export const UserTable = () => {
+  const { data: users = [], isLoading, error } = useQuery({
+    queryKey: ['users'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('Users')
+        .select('*')
+        .order('Name', { ascending: true });
+
+      if (error) {
+        console.error('Error fetching users:', error);
+        throw error;
+      }
+
+      return data || [];
+    }
+  });
+
+  const formatPrice = (price: number) => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD'
+    }).format(price);
+  };
+  
+
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-8">
+        <div className="text-center">Loading users...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-8">
+        <div className="text-center text-red-600">Error loading users: {error.message}</div>
+      </div>
+    );
+  }
+
+  if (users.length === 0) {
+    return (
+      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-8">
+        <div className="text-center text-gray-500">No users found</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          <thead className="bg-gray-50 border-b border-gray-200">
+            <tr>
+              <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                User
+              </th>
+              <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Contact
+              </th>
+              <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Role
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {users.map((user) => (
+              <tr key={user.Uid} className="hover:bg-gray-50">
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <div className="flex items-center">
+                    <div className="w-10 h-10 rounded-full bg-gray-200 mr-4 flex items-center justify-center">
+                      <span className="text-sm text-gray-500">
+                        {user.Name?.charAt(0)?.toUpperCase() || 'U'}
+                      </span>
+                    </div>
+                    <div>
+                      <div className="text-sm font-medium text-gray-900">{user.Name || 'Unknown User'}</div>
+                      <div className="text-sm text-gray-500">ID: {user.Uid}</div>
+                    </div>
+                  </div>
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <div>
+                    <div className="text-sm text-gray-900">{user.Email || 'No email'}</div>
+                    <div className="text-sm text-gray-500">User ID: {user.Uid}</div>
+                  </div>
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap">
+                <span className={`px-2 py-1 rounded-full text-xs font-medium ${
+                  user.role === 'admin'
+                    ? 'bg-red-100 text-red-800'
+                    : 'bg-blue-100 text-blue-800'
+                }`}>
+                  {user.role || 'N/A'}
+                </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -1,0 +1,191 @@
+import * as React from "react"
+
+import type {
+  ToastActionElement,
+  ToastProps,
+} from "@/components/ui/toast"
+
+const TOAST_LIMIT = 1
+const TOAST_REMOVE_DELAY = 1000000
+
+type ToasterToast = ToastProps & {
+  id: string
+  title?: React.ReactNode
+  description?: React.ReactNode
+  action?: ToastActionElement
+}
+
+const actionTypes = {
+  ADD_TOAST: "ADD_TOAST",
+  UPDATE_TOAST: "UPDATE_TOAST",
+  DISMISS_TOAST: "DISMISS_TOAST",
+  REMOVE_TOAST: "REMOVE_TOAST",
+} as const
+
+let count = 0
+
+function genId() {
+  count = (count + 1) % Number.MAX_SAFE_INTEGER
+  return count.toString()
+}
+
+type ActionType = typeof actionTypes
+
+type Action =
+  | {
+      type: ActionType["ADD_TOAST"]
+      toast: ToasterToast
+    }
+  | {
+      type: ActionType["UPDATE_TOAST"]
+      toast: Partial<ToasterToast>
+    }
+  | {
+      type: ActionType["DISMISS_TOAST"]
+      toastId?: ToasterToast["id"]
+    }
+  | {
+      type: ActionType["REMOVE_TOAST"]
+      toastId?: ToasterToast["id"]
+    }
+
+interface State {
+  toasts: ToasterToast[]
+}
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>()
+
+const addToRemoveQueue = (toastId: string) => {
+  if (toastTimeouts.has(toastId)) {
+    return
+  }
+
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId)
+    dispatch({
+      type: "REMOVE_TOAST",
+      toastId: toastId,
+    })
+  }, TOAST_REMOVE_DELAY)
+
+  toastTimeouts.set(toastId, timeout)
+}
+
+export const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case "ADD_TOAST":
+      return {
+        ...state,
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+      }
+
+    case "UPDATE_TOAST":
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === action.toast.id ? { ...t, ...action.toast } : t
+        ),
+      }
+
+    case "DISMISS_TOAST": {
+      const { toastId } = action
+
+      // ! Side effects ! - This could be extracted into a dismissToast() action,
+      // but I'll keep it here for simplicity
+      if (toastId) {
+        addToRemoveQueue(toastId)
+      } else {
+        state.toasts.forEach((toast) => {
+          addToRemoveQueue(toast.id)
+        })
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === toastId || toastId === undefined
+            ? {
+                ...t,
+                open: false,
+              }
+            : t
+        ),
+      }
+    }
+    case "REMOVE_TOAST":
+      if (action.toastId === undefined) {
+        return {
+          ...state,
+          toasts: [],
+        }
+      }
+      return {
+        ...state,
+        toasts: state.toasts.filter((t) => t.id !== action.toastId),
+      }
+  }
+}
+
+const listeners: Array<(state: State) => void> = []
+
+let memoryState: State = { toasts: [] }
+
+function dispatch(action: Action) {
+  memoryState = reducer(memoryState, action)
+  listeners.forEach((listener) => {
+    listener(memoryState)
+  })
+}
+
+type Toast = Omit<ToasterToast, "id">
+
+function toast({ ...props }: Toast) {
+  const id = genId()
+
+  const update = (props: ToasterToast) =>
+    dispatch({
+      type: "UPDATE_TOAST",
+      toast: { ...props, id },
+    })
+  const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id })
+
+  dispatch({
+    type: "ADD_TOAST",
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: (open) => {
+        if (!open) dismiss()
+      },
+    },
+  })
+
+  return {
+    id: id,
+    dismiss,
+    update,
+  }
+}
+
+function useToast() {
+  const [state, setState] = React.useState<State>(memoryState)
+
+  React.useEffect(() => {
+    listeners.push(setState)
+    return () => {
+      const index = listeners.indexOf(setState)
+      if (index > -1) {
+        listeners.splice(index, 1)
+      }
+    }
+  }, [state])
+
+  return {
+    ...state,
+    toast,
+    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+  }
+}
+
+export { useToast, toast }

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -1,0 +1,26 @@
+import { useState } from "react";
+import { Sidebar } from "../components/Sidebar";
+import { OrderTable } from "../components/OrderTable";
+
+const Orders = () => {
+  const [sidebarOpen, setSidebarOpen] = useState(true);
+
+  return (
+    <div className="min-h-screen bg-background flex">
+      <Sidebar isOpen={sidebarOpen} onToggle={() => setSidebarOpen(!sidebarOpen)} />
+      
+      <div className={`flex-1 transition-all duration-300 ${sidebarOpen ? 'ml-64' : 'ml-16'}`}>
+        <div className="p-8">
+          <div className="mb-8">
+            <h1 className="text-3xl font-bold text-foreground mb-2">Order Management</h1>
+            <p className="text-muted-foreground">Track and update order status</p>
+          </div>
+
+          <OrderTable />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Orders;

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import { Sidebar } from "../components/Sidebar";
+import { UserTable } from "../components/UserTable";
+import { NotificationForm } from "../components/NotificationForm";
+import { Bell } from "lucide-react";
+
+const Users = () => {
+  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [showNotificationForm, setShowNotificationForm] = useState(false);
+
+  return (
+    <div className="min-h-screen bg-background flex">
+      <Sidebar isOpen={sidebarOpen} onToggle={() => setSidebarOpen(!sidebarOpen)} />
+      
+      <div className={`flex-1 transition-all duration-300 ${sidebarOpen ? 'ml-64' : 'ml-16'}`}>
+        <div className="p-8">
+          <div className="flex justify-between items-center mb-8">
+            <div>
+              <h1 className="text-3xl font-bold text-foreground mb-2">User Management</h1>
+              <p className="text-muted-foreground">User list and send notifications</p>
+            </div>
+          </div>
+
+          {showNotificationForm ? (
+            <NotificationForm onClose={() => setShowNotificationForm(false)} />
+          ) : (
+            <UserTable />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Users;


### PR DESCRIPTION
Introduces several reusable components (`RecentOrders`, `SalesChart`, `UserTable`), a custom toast notification hook (`use-toast`), and updates to pages (`Orders`, `Users`) for improved interactivity and layout.
